### PR TITLE
Update protocol buffer definition

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@ Antidote.iml
 .gradle/
 build/
 gen/
+out/

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,6 +3,6 @@ services:
   - docker
 language: java
 jdk:
-  - oraclejdk8
+  - oraclejdk11
 before_install:
-  - docker run -d --name antidote -p "8087:8087" antidotedb/antidote:0.2.0
+  - docker run -d --name antidote -p "8087:8087" antidotedb/antidote:0.2.1

--- a/src/main/java/eu/antidotedb/client/AntidoteClient.java
+++ b/src/main/java/eu/antidotedb/client/AntidoteClient.java
@@ -245,9 +245,9 @@ public class AntidoteClient {
             AntidotePB.ApbGetConnectionDescriptor apbGetConnectionDescriptor = AntidotePB.ApbGetConnectionDescriptor.newBuilder()
                     .build();
             SocketSender socketSender = new SocketSender(s);
-            AntidotePB.ApbGetConnectionDescriptorResponse connectionDescriptor = socketSender.handle(apbGetConnectionDescriptor).accept(new AntidoteResponse.MsgGetConnectionDescriptorResponse.Extractor());
+            AntidotePB.ApbGetConnectionDescriptorResp connectionDescriptor = socketSender.handle(apbGetConnectionDescriptor).accept(new AntidoteResponse.MsgGetConnectionDescriptorResponse.Extractor());
             if (connectionDescriptor.getSuccess()) {
-                return connectionDescriptor.getConDesc();
+                return connectionDescriptor.getD();
             } else {
                 throw new IOException("Error getting connection descriptor of node: Error code " + connectionDescriptor.getErrorcode());
             }
@@ -257,7 +257,7 @@ public class AntidoteClient {
     public static boolean connectToDCs(InetSocketAddress managerNode, List<ByteString> descriptors) throws IOException {
         try (Socket s = new Socket()) {
             s.connect(managerNode);
-            AntidotePB.ApbConnectToDcs apbConnectToDcs = AntidotePB.ApbConnectToDcs.newBuilder()
+            AntidotePB.ApbConnectToDCs apbConnectToDcs = AntidotePB.ApbConnectToDCs.newBuilder()
                     .addAllDescriptors(descriptors)
                     .build();
             SocketSender socketSender = new SocketSender(s);

--- a/src/main/java/eu/antidotedb/client/AntidoteStaticTransaction.java
+++ b/src/main/java/eu/antidotedb/client/AntidoteStaticTransaction.java
@@ -1,5 +1,6 @@
 package eu.antidotedb.client;
 
+import eu.antidotedb.antidotepb.AntidotePB;
 import eu.antidotedb.antidotepb.AntidotePB.ApbCommitResp;
 import eu.antidotedb.antidotepb.AntidotePB.ApbStartTransaction;
 import eu.antidotedb.antidotepb.AntidotePB.ApbStaticUpdateObjects;
@@ -66,16 +67,22 @@ public class AntidoteStaticTransaction extends AntidoteTransaction {
      */
     protected ApbStaticUpdateObjects createUpdateStaticObject() {
         ApbStaticUpdateObjects.Builder updateMessage = ApbStaticUpdateObjects.newBuilder(); // Message which will be sent to antidote
-        ApbStartTransaction.Builder startTransaction = ApbStartTransaction.newBuilder();
-        if (timestamp != null) {
-            startTransaction.setTimestamp(timestamp.getCommitTime());
-        }
+        ApbStartTransaction.Builder startTransaction = newStartTransaction(timestamp);
         updateMessage.setTransaction(startTransaction);
         // TODO could optimize this by combining updates on same key
         for (ApbUpdateOp.Builder updateInstruction : transactionUpdateList) {
             updateMessage.addUpdates(updateInstruction);
         }
         return updateMessage.build();
+    }
+
+    protected static ApbStartTransaction.Builder newStartTransaction(CommitInfo timestamp) {
+        ApbStartTransaction.Builder startTransaction = ApbStartTransaction.newBuilder();
+        startTransaction.setProperties(AntidotePB.ApbTxnProperties.newBuilder());
+        if (timestamp != null) {
+            startTransaction.setTimestamp(timestamp.getCommitTime());
+        }
+        return startTransaction;
     }
 
 

--- a/src/main/java/eu/antidotedb/client/ApbCoder.java
+++ b/src/main/java/eu/antidotedb/client/ApbCoder.java
@@ -61,7 +61,7 @@ public class ApbCoder {
                 AntidotePB.ApbCreateDC apbCreateDC = AntidotePB.ApbCreateDC.parseFrom(data);
                 return AntidoteRequest.of(apbCreateDC);
             case ApbConnectToDCs:
-                AntidotePB.ApbConnectToDcs apbConnectToDcs = AntidotePB.ApbConnectToDcs.parseFrom(data);
+                AntidotePB.ApbConnectToDCs apbConnectToDcs = AntidotePB.ApbConnectToDCs.parseFrom(data);
                 return AntidoteRequest.of(apbConnectToDcs);
             case ApbGetConnectionDescriptor:
                 AntidotePB.ApbGetConnectionDescriptor apbGetConnectionDescriptor = AntidotePB.ApbGetConnectionDescriptor.parseFrom(data);
@@ -109,7 +109,7 @@ public class ApbCoder {
                 AntidotePB.ApbStaticReadObjectsResp apbStaticReadObjectsResp = AntidotePB.ApbStaticReadObjectsResp.parseFrom(data);
                 return AntidoteResponse.of(apbStaticReadObjectsResp);
             case ApbGetConnectionDescriptorResponse:
-                AntidotePB.ApbGetConnectionDescriptorResponse apbGetConnectionDescriptorResponse = AntidotePB.ApbGetConnectionDescriptorResponse.parseFrom(data);
+                AntidotePB.ApbGetConnectionDescriptorResp apbGetConnectionDescriptorResponse = AntidotePB.ApbGetConnectionDescriptorResp.parseFrom(data);
                 return AntidoteResponse.of(apbGetConnectionDescriptorResponse);
             default:
                 throw new RuntimeException("Unexpected message code: " + msgCode);
@@ -159,7 +159,7 @@ public class ApbCoder {
         encode(ApbCreateDC, op, stream);
     }
 
-    public static void encodeRequest(AntidotePB.ApbConnectToDcs op, OutputStream stream) {
+    public static void encodeRequest(AntidotePB.ApbConnectToDCs op, OutputStream stream) {
         encode(ApbConnectToDCs, op, stream);
     }
 
@@ -188,7 +188,7 @@ public class ApbCoder {
         encode(128, op, stream);
     }
 
-    public static void encodeResponse(AntidotePB.ApbGetConnectionDescriptorResponse op, OutputStream stream) {
+    public static void encodeResponse(AntidotePB.ApbGetConnectionDescriptorResp op, OutputStream stream) {
         encode(ApbGetConnectionDescriptorResponse, op, stream);
     }
 
@@ -260,7 +260,7 @@ public class ApbCoder {
             }
 
             @Override
-            public Void handle(AntidotePB.ApbConnectToDcs op) {
+            public Void handle(AntidotePB.ApbConnectToDCs op) {
                 encodeRequest(op, stream);
                 return null;
             }

--- a/src/main/java/eu/antidotedb/client/InteractiveTransaction.java
+++ b/src/main/java/eu/antidotedb/client/InteractiveTransaction.java
@@ -57,13 +57,9 @@ public class InteractiveTransaction extends TransactionWithReads implements Auto
     }
 
     private void startTransaction(CommitInfo timestamp) {
-        ApbTxnProperties.Builder transactionProperties = ApbTxnProperties.newBuilder();
 
-        ApbStartTransaction.Builder readwriteTransaction = ApbStartTransaction.newBuilder();
-        readwriteTransaction.setProperties(transactionProperties);
-        if (timestamp != null) {
-            readwriteTransaction.setTimestamp(timestamp.getCommitTime());
-        }
+        ApbStartTransaction.Builder readwriteTransaction = AntidoteStaticTransaction.newStartTransaction(timestamp);
+
 
         ApbStartTransaction startTransactionMessage = readwriteTransaction.build();
         AntidotePB.ApbStartTransactionResp transactionResponse = getClient().sendMessage(AntidoteRequest.of(startTransactionMessage), connection);

--- a/src/main/java/eu/antidotedb/client/NoTransaction.java
+++ b/src/main/java/eu/antidotedb/client/NoTransaction.java
@@ -34,10 +34,7 @@ public class NoTransaction extends TransactionWithReads {
     @Override
     void performUpdates(Collection<AntidotePB.ApbUpdateOp.Builder> updateInstructions) {
         AntidotePB.ApbStaticUpdateObjects.Builder updateMessage = AntidotePB.ApbStaticUpdateObjects.newBuilder(); // Message which will be sent to antidote
-        AntidotePB.ApbStartTransaction.Builder startTransaction = AntidotePB.ApbStartTransaction.newBuilder();
-        if (timestamp != null) {
-            startTransaction.setTimestamp(timestamp.getCommitTime());
-        }
+        AntidotePB.ApbStartTransaction.Builder startTransaction = AntidoteStaticTransaction.newStartTransaction(timestamp);
         updateMessage.setTransaction(startTransaction);
         for (AntidotePB.ApbUpdateOp.Builder updateInstruction : updateInstructions) {
             updateMessage.addUpdates(updateInstruction);
@@ -55,7 +52,7 @@ public class NoTransaction extends TransactionWithReads {
                 .setType(type)
                 .setKey(key);
         readMessage.addObjects(obj);
-        AntidotePB.ApbStartTransaction.Builder startTransaction = AntidotePB.ApbStartTransaction.newBuilder();
+        AntidotePB.ApbStartTransaction.Builder startTransaction = AntidoteStaticTransaction.newStartTransaction(timestamp);
         readMessage.setTransaction(startTransaction);
 
         AntidotePB.ApbStaticReadObjectsResp resp =
@@ -70,7 +67,7 @@ public class NoTransaction extends TransactionWithReads {
         for (BatchReadResultImpl request : requests) {
             readObject.addObjects(request.getObject());
         }
-        readObject.setTransaction(AntidotePB.ApbStartTransaction.newBuilder().build());
+        readObject.setTransaction(AntidoteStaticTransaction.newStartTransaction(timestamp));
 
         AntidotePB.ApbStaticReadObjects readObjectsMessage = readObject.build();
         Connection connection = client.getPoolManager().getConnection();

--- a/src/main/java/eu/antidotedb/client/SocketSender.java
+++ b/src/main/java/eu/antidotedb/client/SocketSender.java
@@ -104,7 +104,7 @@ class SocketSender implements Transformer {
     }
 
     @Override
-    public AntidoteResponse handle(AntidotePB.ApbConnectToDcs op) {
+    public AntidoteResponse handle(AntidotePB.ApbConnectToDCs op) {
         try {
             ApbCoder.encodeRequest(op, socket.getOutputStream());
             return ApbCoder.decodeResponse(socket.getInputStream());

--- a/src/main/java/eu/antidotedb/client/messages/AntidoteRequest.java
+++ b/src/main/java/eu/antidotedb/client/messages/AntidoteRequest.java
@@ -54,7 +54,7 @@ public abstract class AntidoteRequest<Response> extends AntidoteMessage {
             throw new ExtractionError("Unexpected message: " + op);
         }
 
-        default V handle(AntidotePB.ApbConnectToDcs op) {
+        default V handle(AntidotePB.ApbConnectToDCs op) {
             throw new ExtractionError("Unexpected message: " + op);
         }
 
@@ -110,7 +110,7 @@ public abstract class AntidoteRequest<Response> extends AntidoteMessage {
         return new MsgCreateDC(op);
     }
 
-    public static MsgConnectToDCs of(AntidotePB.ApbConnectToDcs op) {
+    public static MsgConnectToDCs of(AntidotePB.ApbConnectToDCs op) {
         return new MsgConnectToDCs(op);
     }
 
@@ -404,18 +404,18 @@ public abstract class AntidoteRequest<Response> extends AntidoteMessage {
     }
 
     private static class MsgConnectToDCs extends AntidoteRequest<AntidotePB.ApbOperationResp> {
-        private final AntidotePB.ApbConnectToDcs op;
+        private final AntidotePB.ApbConnectToDCs op;
 
-        public static class Extractor implements Handler<AntidotePB.ApbConnectToDcs> {
+        public static class Extractor implements Handler<AntidotePB.ApbConnectToDCs> {
 
 
             @Override
-            public AntidotePB.ApbConnectToDcs handle(AntidotePB.ApbConnectToDcs op) {
+            public AntidotePB.ApbConnectToDCs handle(AntidotePB.ApbConnectToDCs op) {
                 return op;
             }
         }
 
-        private MsgConnectToDCs(AntidotePB.ApbConnectToDcs apbConnectToDcs) {
+        private MsgConnectToDCs(AntidotePB.ApbConnectToDCs apbConnectToDcs) {
             this.op = apbConnectToDcs;
         }
 
@@ -430,7 +430,7 @@ public abstract class AntidoteRequest<Response> extends AntidoteMessage {
         }
     }
 
-    private static class MsgGetConnectionDescriptor extends AntidoteRequest<AntidotePB.ApbGetConnectionDescriptorResponse> {
+    private static class MsgGetConnectionDescriptor extends AntidoteRequest<AntidotePB.ApbGetConnectionDescriptorResp> {
         private final AntidotePB.ApbGetConnectionDescriptor op;
 
         public static class Extractor implements Handler<AntidotePB.ApbGetConnectionDescriptor> {
@@ -452,7 +452,7 @@ public abstract class AntidoteRequest<Response> extends AntidoteMessage {
         }
 
         @Override
-        public AntidoteResponse.Handler<AntidotePB.ApbGetConnectionDescriptorResponse> readResponseExtractor() {
+        public AntidoteResponse.Handler<AntidotePB.ApbGetConnectionDescriptorResp> readResponseExtractor() {
             return new AntidoteResponse.MsgGetConnectionDescriptorResponse.Extractor();
         }
     }

--- a/src/main/java/eu/antidotedb/client/messages/AntidoteResponse.java
+++ b/src/main/java/eu/antidotedb/client/messages/AntidoteResponse.java
@@ -46,7 +46,7 @@ public abstract class AntidoteResponse extends AntidoteMessage {
             throw new ExtractionError(this.getClass() + " - Unexpected message: " + op);
         }
 
-        default V handle(AntidotePB.ApbGetConnectionDescriptorResponse op) {
+        default V handle(AntidotePB.ApbGetConnectionDescriptorResp op) {
             throw new ExtractionError(this.getClass() + " - Unexpected message: " + op);
         }
 
@@ -92,7 +92,7 @@ public abstract class AntidoteResponse extends AntidoteMessage {
         return new MsgStaticReadObjectsResp(op);
     }
 
-    public static AntidoteResponse of(AntidotePB.ApbGetConnectionDescriptorResponse op) {
+    public static AntidoteResponse of(AntidotePB.ApbGetConnectionDescriptorResp op) {
         return new MsgGetConnectionDescriptorResponse(op);
     }
 
@@ -326,16 +326,16 @@ public abstract class AntidoteResponse extends AntidoteMessage {
     }
 
     public static class MsgGetConnectionDescriptorResponse extends AntidoteResponse {
-        private AntidotePB.ApbGetConnectionDescriptorResponse op;
+        private AntidotePB.ApbGetConnectionDescriptorResp op;
 
-        public static class Extractor implements Handler<AntidotePB.ApbGetConnectionDescriptorResponse> {
+        public static class Extractor implements Handler<AntidotePB.ApbGetConnectionDescriptorResp> {
             @Override
-            public AntidotePB.ApbGetConnectionDescriptorResponse handle(AntidotePB.ApbGetConnectionDescriptorResponse op) {
+            public AntidotePB.ApbGetConnectionDescriptorResp handle(AntidotePB.ApbGetConnectionDescriptorResp op) {
                 return op;
             }
         }
 
-        private MsgGetConnectionDescriptorResponse(AntidotePB.ApbGetConnectionDescriptorResponse op) {
+        private MsgGetConnectionDescriptorResponse(AntidotePB.ApbGetConnectionDescriptorResp op) {
             this.op = op;
         }
 

--- a/src/main/proto/eu/antidotedb/proto/antidote.proto
+++ b/src/main/proto/eu/antidotedb/proto/antidote.proto
@@ -1,3 +1,5 @@
+syntax = "proto2";
+
 // Java package specifiers
 option java_package = "eu.antidotedb.antidotepb";
 option java_outer_classname = "AntidotePB";
@@ -14,6 +16,7 @@ enum CRDT_type {
     FATCOUNTER = 12;
     FLAG_EW = 13;
     FLAG_DW = 14;
+    BCOUNTER = 15;
 }
 
 // Riak Error response
@@ -25,7 +28,7 @@ message ApbErrorResp {
 //------------------
 // Counter
 
-// Counter increment requenst
+// Counter increment request
 message ApbCounterUpdate {
     // inc indicates the value to be incremented. To decrement, use a negative value. If no value is given, it will be considered as an increment by 1
     optional sint64 inc = 1;
@@ -119,8 +122,6 @@ message ApbGetFlagResp {
     required bool value = 1;
 }
 
-
-
 // General reset operation
 message ApbCrdtReset {
 
@@ -139,6 +140,8 @@ message ApbOperationResp {
 message ApbTxnProperties {
     optional uint32 read_write = 1 ; //default = 0 = read_write, 1 = read_only, 2 = write_only
     optional uint32 red_blue = 2 ; // default = 0 = blue, 1 = red
+    repeated bytes shared_locks = 3;
+    repeated bytes exclusive_locks = 4;
 }
 
 // Object (Key) representation
@@ -161,12 +164,12 @@ message ApbUpdateOp {
 }
 
 message ApbUpdateOperation { // TODO use this above
-                             optional ApbCounterUpdate counterop = 1;
-                             optional ApbSetUpdate setop = 2;
-                             optional ApbRegUpdate regop = 3;
-                             optional ApbMapUpdate mapop = 5;
-                             optional ApbCrdtReset resetop = 6;
-                             optional ApbFlagUpdate flagop = 7;
+    optional ApbCounterUpdate counterop = 1;
+    optional ApbSetUpdate setop = 2;
+    optional ApbRegUpdate regop = 3;
+    optional ApbMapUpdate mapop = 5;
+    optional ApbCrdtReset resetop = 6;
+    optional ApbFlagUpdate flagop = 7;
 }
 
 // Objects to be updated
@@ -239,20 +242,36 @@ message ApbStaticReadObjectsResp {
 
 //------------ Cluster Management API ---------
 
-message ApbCreateDC{
-    repeated string nodes = 1;
+// Create a DC with multiple nodes
+message ApbCreateDC {
+  // name of antidote nodes of the form 'antidote@hostname' or 'antidote@ip'
+  repeated string nodes = 1;
 }
 
-message ApbGetConnectionDescriptor{
+message ApbCreateDCResp {
+  required bool success = 1;
+  optional uint32 errorcode = 2;
 }
 
-message ApbGetConnectionDescriptorResponse{
-    required bool success = 1;
-    //structure of descriptor is internal to antidote.
-    optional bytes conDesc = 2;
-    optional uint32 errorcode = 3;
+// Get a connection descriptor of the DC to be given to other DCs.
+message ApbGetConnectionDescriptor {
 }
 
-message ApbConnectToDcs{
+message ApbGetConnectionDescriptorResp {
+  required bool success = 1;
+  //structure of descriptor is internal to antidote.
+  optional bytes descriptor = 2;
+  optional uint32 errorcode = 3;
+}
+
+// Connect DC with each other to start replication.
+// This message must be send to all DCs.
+message ApbConnectToDCs {
+  // descriptors is a list of connection information of all DCs obtained from ApbGetConnectionDescriptorResp.descriptor
     repeated bytes descriptors = 1;
+}
+
+message ApbConnectToDCsResp {
+  required bool success = 1;
+  optional uint32 errorcode = 2;
 }

--- a/src/main/proto/eu/antidotedb/proto/antidote.proto
+++ b/src/main/proto/eu/antidotedb/proto/antidote.proto
@@ -260,7 +260,7 @@ message ApbGetConnectionDescriptor {
 message ApbGetConnectionDescriptorResp {
   required bool success = 1;
   //structure of descriptor is internal to antidote.
-  optional bytes descriptor = 2;
+  optional bytes d = 2;
   optional uint32 errorcode = 3;
 }
 


### PR DESCRIPTION
Updates the Java client with the protocol buffer changes from September.

(The new functionality is not yet exposed in the user API, but the changes are necessary for the client to work with latest Antidote, see #5)

